### PR TITLE
Fix std:max argument type

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,25 @@
+name: Build and Test
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      - name: Build
+        run: |
+          mkdir build
+          cd build
+          cmake ..
+          cmake --build .

--- a/xxtea.hpp
+++ b/xxtea.hpp
@@ -54,7 +54,8 @@ std::vector<BlockType> to_blocks(std::string string) {
 
     auto number_of_bits = string.size() * CHAR_BIT;
     std::vector<BlockType> blocks{};
-    auto n_blocks = std::max(number_of_bits / block_size, 1UL);
+    auto n_blocks = number_of_bits / block_size;
+    n_blocks = std::max(n_blocks, decltype(n_blocks){1});
     blocks.resize(n_blocks, 0);
 
     constexpr auto fit_size = block_size / CHAR_BIT;


### PR DESCRIPTION
This PR fixes a build error using various compilers. std::max required both arguments to be the same type. Hardcoding it to unsigned long caused issues with the implementation defined first parameter.

This PR also adds basic Github Actions to test building on all major OS.